### PR TITLE
Update Partner Guide

### DIFF
--- a/source/docs/guides/partner_quickstart/index.md
+++ b/source/docs/guides/partner_quickstart/index.md
@@ -14,27 +14,58 @@ navigation:
 
 # Partner Quickstart
 
-Welcome to our partner setup guide. Learn how to request your partner account, and how to test the Onboarding API.
+With this guide, we'll quickly cover how to request a Partner account, and test the Onboarding API after creating your own sandbox account.
 
-This guide will show you how to create and configure a test account.
+## Request a partner account
 
-This guide builds on the [Merchant Quickstart Guide](/docs/guides/merchant_quickstart/).
+After you [request a partner account](https://dev.na.bambora.com/docs/forms/request_partner_account/), we'll supply you with API key for our sandbox environment.
 
-## 1. Request a partner account
+## Authenticating customers
 
-You can request a partner account [here](/docs/forms/request_partner_account). You will be emailed an API key for our sandbox environment.
-
-## 2. Authentication for Sub-Merchant
-Partners can make Merchant API calls on behalf of their sub-merchants if they are configured to do so. You can request this to be enabled.
-
-You will need an Authorization header as described in the [Merchant Quickstart Guide](/docs/guides/merchant_quickstart/):
+As a Partner, Payment API calls can be made on behalf of customers, if you're configured. Similarly to the [Merchant Quickstart Guide](https://dev.na.bambora.com/docs/guides/merchant_quickstart/),  you'll need an Authorisation header.
 
 ```
 Authorization: Passcode Base64Encoded(your_partner_merchant_id:passcode)
 ```
- 
-To process on behalf of a sub-merchant you will need a header with the merchant Id of your sub-merchant:
+
+When processing on behalf of a customer, you'll need a header that includes their merchant ID.
 
 ```
 Sub-Merchant-Id: your_sub_merchant_id
 ```
+
+## Creating a partial application
+
+To reach our [Onboarding API endpoints](https://dev.na.bambora.com/docs/references/onboarding_API/), you'll need the authentication passcode provided with your partner sandbox account. The sample below outlines the account flow of PSP-CAD.
+
+> You can read more about the PSP-CAD flow, and others in our [Onboarding Guide](https://dev.na.bambora.com/docs/guides/onboarding)
+
+```shell
+curl https://uat-onboarding-api.beanstream.com/v1/workflows/psp-cad/applications  \
+  -H "Authorization: Passcode your_onboarding_passcode"  \
+  -H "Content-Type: application/json" \
+  -d '{
+  "pricing_id":"your_pricing_ID",
+  "applicant":{
+    "first_name":"John",
+    "last_name":"Doe",
+    "phone_number":"222-222-2222",
+    "date_of_birth":"2018-03-25T00:00:00.04399Z",
+    "email":"person@email.com"
+  }
+}'
+```
+
+As a response, you'll receive an HTTP 201 confirming creation. The response body will contain an ID for the application, and an array for incomplete fields. Until you've completed all required fields, your application will be set as `in_progress`.
+
+## Retrieve the application.
+
+To retrieve the partially completed application, you'll complete a call using the ID from the response.
+
+```
+curl https://uat-onboarding-api.bambora.com/v1/workflows/psp-cad/applications/{applicationId}
+```
+
+## Learn about Onboarding
+
+To read more about the application process, check out our [Onboarding Guide](https://dev.na.bambora.com/docs/guides/onboarding) and our [Onboarding API specifications.](https://dev.na.bambora.com/docs/references/onboarding_API/)


### PR DESCRIPTION
This is re-written partner guide, removing the need for the Calling APIs child page (https://dev.na.bambora.com/docs/guides/partner_quickstart/calling_APIs/).