### PR TITLE
WEB-1035 - adds 'live' status for applications

### DIFF
--- a/source/docs/references/onboarding_API/index.md
+++ b/source/docs/references/onboarding_API/index.md
@@ -111,6 +111,9 @@ The following workflows are currently supported:
 
 [Specification](./v2016-06-11)
 
+#### November 9th, 2017
+* Added new 'live' status as possible return value for all flows.
+
 #### July 20th, 2017
 * Added optional custom_data field to all flows.
 


### PR DESCRIPTION
Now possible to get the value 'live' back as a status for applications on all flows. This updates the changelog, actual change exists in swagger file which will be available on build.