### PR TITLE
Update report.md

### DIFF
--- a/source/docs/guides/batch_payment/report.md
+++ b/source/docs/guides/batch_payment/report.md
@@ -238,7 +238,7 @@ curl -X POST \
 #### Settlement request
 ```bash
 curl -X POST \
-  https://dbft.na.bambora.com/scripts/reporting/report.aspx \
+  https://api.na.bambora.com/scripts/reporting/report.aspx \
   -H 'content-type: application/xml' \
   -d '<?xml version="1.0" encoding="utf-8"?>
 <request>


### PR DESCRIPTION
Fixing the URL in the settlement request sample, dbft is a backup server and should not be publicly documented.