### PR TITLE
PAY-2243 allow for markdown to be displayed in swagger spec descriptions

### DIFF
--- a/source/layouts/_swagger_partials/_property.erb
+++ b/source/layouts/_swagger_partials/_property.erb
@@ -36,7 +36,11 @@
     <% printed_fields.each do |field| %>
       <% if property[field] %>
         <span class="property-detail">
-          <%= field %>: <%= property[field] %>
+          <% if field == 'description' %>
+            <%= field %>: <%= render_markdown property[field] %>
+          <% else %>
+            <%= field %>: <%= property[field] %>
+          <% end %>
         </span>
       <% end %>
     <% end %>


### PR DESCRIPTION
PAY-2243 allow for markdown to be displayed in swagger spec descriptions