### PR TITLE
ZOO-1249 Document defaults for "complete" field

### DIFF
--- a/data/na/swagger/1-0-5.yaml
+++ b/data/na/swagger/1-0-5.yaml
@@ -788,7 +788,8 @@ definitions:
     properties:
       complete:
         type: boolean
-        description: Set to FALSE for pre-auth. digit(1) or boolean
+        default: true
+        description: 'set to false for Pre-Authorize, and true to complete a payment'
       customer_code:
         type: string
         maxLength: 32
@@ -805,7 +806,8 @@ definitions:
     properties:
       complete:
         type: boolean
-        description: Set to FALSE for pre-auth
+        default: false
+        description: 'set to false for Pre-Authorize, and true to complete a payment'
       code:
         type: string
         maxLength: 36


### PR DESCRIPTION
Context: When calling the /payments endpoint you can include an optional 'complete' flag that is used to trigger a PA (false) or P (true) transaction.  

Fix: Update documentation to show what the default value is for this optional field since it is not consistent across payment types.

token- "complete" field defaults to false
card- "complete" field defaults to true
profile - "complete" field defaults to true