### PR TITLE
Add instructions to generate static site via docker

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -5,7 +5,7 @@
         "code_blocks": false
     },
     "MD007": {
-        "indent": 4
+        "indent": 2
     },
     "no-hard-tabs": false
 }

--- a/README.md
+++ b/README.md
@@ -83,22 +83,29 @@ docker run -v $pwd/:/usr/src/app/ -p 4567:4567 -w /usr/src/app devbamboracom dev
 
 #### Build Static Site Locally
 
-To build the same content that our CI server builds & deploys, you can execute the following commands:
+To build the same content that our CI server builds & deploys, you can do the following:
+
+- create a local directory for the output:
 
 ```shell
 mkdir build
+```
+
+- generate the content via Docker into that directory:
+
+```shell
 docker run -e ONBOARDING_HOST=test-onboardingapi -v `pwd`/build:/usr/src/app/build devbamboracom static
 ```
 
-Then inspect the `build/` folder which will contain the generated static site.  If you'd like
-to preview that in a browser, you can spin up a local Python HTTP server to serve it:
+- inspect the `build/` folder which will contain the generated static site.
+- to preview that in a browser, spin up a local Python HTTP server to serve it:
 
 ```shell
 cd build
 python -m $(python -c 'import sys; print("http.server" if sys.version_info[:2] > (2,7) else "SimpleHTTPServer")')
 ```
 
-Then navigate to <http://0.0.0.0:8000> and you should see the docs homepage.
+- navigate to <http://0.0.0.0:8000> and you should see the docs homepage.
 
 ### Bundler
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
     - [Docker](#docker)
       - [Build](#build)
       - [Run](#run)
+        - [Mac and Linux](#mac-and-linux)
+        - [Windows](#windows)
       - [Test Local](#test-local)
+      - [Build Static Site Locally](#build-static-site-locally)
     - [Bundler](#bundler)
       - [Build](#build-1)
       - [Run](#run-1)
@@ -47,7 +50,8 @@
 
 ### Docker
 
-The simplest way to get set up is to use the included Dockerfile (must install docker first).
+The simplest way to get set up is to use the included Dockerfile (must install
+[docker](https://www.docker.com) first).
 
 #### Build
 
@@ -57,13 +61,13 @@ docker build -t devbamboracom .
 
 #### Run
 
-*Mac and Linux*
+##### Mac and Linux
 
 ```shell
 docker run -v `pwd`/:/usr/src/app/ -p 4567:4567 -w /usr/src/app devbamboracom development_server
 ```
 
-*Windows*
+##### Windows
 
 ```shell
 docker run -v $pwd/:/usr/src/app/ -p 4567:4567 -w /usr/src/app devbamboracom development_server_windows
@@ -75,24 +79,47 @@ docker run -v $pwd/:/usr/src/app/ -p 4567:4567 -w /usr/src/app devbamboracom dev
 
 <http://localhost:4567/>
 
-**Note**: The site will update with changes you make when a page is reloaded.
+**Note**: The site will update with changes you make when a page is reloaded as this is run in
+development mode.
+
+#### Build Static Site Locally
+
+To build the same content that our CI server builds & deploys, you can execute the following commands:
+
+```shell
+mkdir build
+docker run -e ONBOARDING_HOST=test-onboardingapi -v `pwd`/build:/usr/src/app/build devbamboracom static
+```
+
+Then inspect the `build/` folder which will contain the generated static site.  If you'd like
+to preview that in a browser, you can spin up a local Python HTTP server to serve it:
+
+```shell
+cd build
+python -m $(python -c 'import sys; print("http.server" if sys.version_info[:2] > (2,7) else "SimpleHTTPServer")')
+```
+
+Then navigate to <http://0.0.0.0:8000> and you should see the docs homepage.
 
 ### Bundler
 
 Alternatively, you can build and run the site locally. You're going to need:
-* **Ruby, version 1.9.3 or newer**
-* **Node.js**
-* **Bundler**
-    *  If Ruby is already installed, but the `bundle` command doesn't work run:
+
+- **Ruby, version 1.9.3 or newer**
+- **Node.js**
+- **Bundler**
+  - If Ruby is already installed, but the `bundle` command doesn't work run:
 
     ```gem install bundler```
 
 #### Build
+
 ```shell
 bundle install
 ```
 
 #### Run
+
 To start the preview web server:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ docker run -v $pwd/:/usr/src/app/ -p 4567:4567 -w /usr/src/app devbamboracom dev
 
 <http://localhost:4567/>
 
-**Note**: The site will update with changes you make when a page is reloaded as this is run in
-development mode.
+**Note**: The site will update with changes you make when a page is refreshed.
 
 #### Build Static Site Locally
 


### PR DESCRIPTION
While testing the dependabot update I had to figure out how to generate the static site content locally.  Might as well add that info to the readme as it's useful for testing stuff out.