### PR TITLE
Visa checkout rebrand

### DIFF
--- a/data/na/swagger/1-0-5.yaml
+++ b/data/na/swagger/1-0-5.yaml
@@ -1002,8 +1002,8 @@ definitions:
       card_type:
         type: string
         maxLength: 2
-        description: 'The type of card used in the transaction. AM = American Express, DI = Diners, JB = JCB, MC = MasterCard, NN = Discover, VI = Visa'
-        enum: ['AM','DI','JB','MC','NN''VI']
+        description: 'The type of card used in the transaction. AM = American Express, DI = Diners, JB = JCB, MC = Mastercard, MD = Mastercard Debit, NN = Discover, VI = Visa, PV = Visa Debit'
+        enum: ['AM','DI','JB','MC','MD','NN','VI','PV']
       last_four:
         type: string
         maxLength: 4

--- a/data/na/swagger/1-0-5.yaml
+++ b/data/na/swagger/1-0-5.yaml
@@ -1002,8 +1002,8 @@ definitions:
       card_type:
         type: string
         maxLength: 2
-        description: 'The type of card used in the transaction. AM = American Express, DI = Diners, JB = JCB, MC = Mastercard, MD = Mastercard Debit, NN = Discover, VI = Visa, PV = Visa Debit'
-        enum: ['AM','DI','JB','MC','MD','NN','VI','PV']
+        description: 'The type of card used in the transaction. AM = American Express, DI = Diners, JB = JCB, MC = MasterCard, NN = Discover, VI = Visa'
+        enum: ['AM','DI','JB','MC','NN''VI']
       last_four:
         type: string
         maxLength: 4

--- a/data/na/tocs/guides.yaml
+++ b/data/na/tocs/guides.yaml
@@ -27,4 +27,4 @@
 - file: '/docs/guides/SSL'
   title: 'SSL'
 - file: '/docs/guides/visa_checkout'
-  title: 'Visa Checkout'
+  title: 'Visa Secure Remote Commerce'

--- a/source/docs/guides/credential_on_file/index.md
+++ b/source/docs/guides/credential_on_file/index.md
@@ -38,7 +38,7 @@ Credential-on-File indicator for Credential-on-File transactions.  The new JSON 
 ```
 
 This new JSON object is also returned back as part of the PaymentResponse JSON object, identifying the Credential-on-File type that the transaction 
-was processed as, and the series ID that it belongs to.
+was processed as, and the series ID that it belongs to. The series ID is unique for each merchant account, and cannot be used to reference a string of transactions from anothe account.
 
 For documentation on how to call our Payment APIs click <a href="https://dev.na.bambora.com/docs/guides/merchant_quickstart/calling_APIs/">here</a>.
 

--- a/source/docs/guides/credential_on_file/index.md
+++ b/source/docs/guides/credential_on_file/index.md
@@ -38,7 +38,7 @@ Credential-on-File indicator for Credential-on-File transactions.  The new JSON 
 ```
 
 This new JSON object is also returned back as part of the PaymentResponse JSON object, identifying the Credential-on-File type that the transaction 
-was processed as, and the series ID that it belongs to. The series ID is unique for each merchant account, and cannot be used to reference a string of transactions from anothe account.
+was processed as, and the series ID that it belongs to. The series ID is unique for each merchant account, and cannot be used to reference a string of transactions from another account.
 
 For documentation on how to call our Payment APIs click <a href="https://dev.na.bambora.com/docs/guides/merchant_quickstart/calling_APIs/">here</a>.
 

--- a/source/docs/guides/index.md
+++ b/source/docs/guides/index.md
@@ -96,9 +96,9 @@ cards:
         icon: checkmark
         link: /docs/guides/SSL
     -
-        title: Visa Checkout
+        title: Visa Secure Remote Commerce
         description: >
-            Process payments with Visa Checkout.
+            Process payments with Visa Secure Remote Commerce (SRC).
         icon: creditcard-outline
         link: /docs/guides/visa_checkout
 ---

--- a/source/docs/guides/merchant_quickstart/calling_APIs.md
+++ b/source/docs/guides/merchant_quickstart/calling_APIs.md
@@ -91,8 +91,8 @@ curl https://api.na.bambora.com/v1/payments  \
      "amount":100.00,
      "payment_method":"payment_profile",
      "payment_profile":{
-       "customer_code":"John Doe",
-       "card_id":"your_customer_token",
+       "customer_code":"D08a4F40374EF8c167aA0471B",
+       "card_id":"1",
        "complete":"true"
      }
   }'

--- a/source/docs/guides/visa_checkout.md
+++ b/source/docs/guides/visa_checkout.md
@@ -17,7 +17,7 @@ navigation:
 
 # Visa Secure Remote Commerce
 
-Visa SRC simplifies and secures online payments by storing payment information.
+Visa SRC (formerly Visa Checkout) simplifies and secures online payments by storing payment information.
 It removes the need for a customer to re-enter and share card information.
 
 Visa SRC is a digital wallet. Customers load their digital wallet with their credit, debit and prepaid cards once. They can then retrieve their payment information at any checkout supporting the wallet.
@@ -30,7 +30,7 @@ time checking out. Visa SRC benefits merchants by reducing checkout abandonment.
 
 A Visa SRC payment can involve either one or two steps for a merchant.
 
-It will always begin with a user choosing the 'click to pay' button. Visa's
+It will always begin with a user choosing the 'click to pay' button in the checkout flow. Visa's
 SDK handles the event and pops a lightbox where the user can authenticate and select a payment card.
 Visa SRC then calls a callback function on the merchant's webpage.
 

--- a/source/docs/guides/visa_checkout.md
+++ b/source/docs/guides/visa_checkout.md
@@ -1,11 +1,11 @@
 ---
-title: Visa Checkout
+title: Visa Secure Remote Commerce (SRC)
 layout: tutorial
 
 summary: >
-    You can use Visa Checkout to integrate Visa’s digital payment service with Bambora’s payment gateway.
-    Visa Checkout is a digital payment service where consumers can store card information for Visa, MasterCard,
-    Discover, and American Express. Visa Checkout provides quick integration for merchants to accept payments
+    You can use Visa Secure Remote Commerce to integrate Visa’s digital payment service with Bambora’s payment gateway.
+    Visa SRC is a digital payment service where consumers can store card information for Visa, MasterCard,
+    Discover, and American Express. Visa SRC provides quick integration for merchants to accept payments
     from these card holders.
 
 navigation:
@@ -15,24 +15,24 @@ navigation:
   header_active: Guides
 ---
 
-# Visa Checkout
+# Visa Secure Remote Commerce
 
-Visa Checkout simplifies and secures online payments by storing payment information.
+Visa SRC simplifies and secures online payments by storing payment information.
 It removes the need for a customer to re-enter and share card information.
 
-Visa Checkout is a digital wallet. Customers load their digital wallet with their credit, debit and prepaid cards once. They can then retrieve their payment information at any checkout supporting the wallet.
+Visa SRC is a digital wallet. Customers load their digital wallet with their credit, debit and prepaid cards once. They can then retrieve their payment information at any checkout supporting the wallet.
 
-Visa Checkout benefits users by securing their payment information and saving them
-time checking out. MasterPass benefits merchants by reducing checkout abandonment.
+Visa SRC benefits users by securing their payment information and saving them
+time checking out. Visa SRC benefits merchants by reducing checkout abandonment.
 
 
 ## Standard integration
 
-A Visa Checkout payment can involve either one or two steps for a merchant.
+A Visa SRC payment can involve either one or two steps for a merchant.
 
-It will always begin with a user clicking on a Visa Checkout button. Visa Checkout's
+It will always begin with a user choosing the 'click to pay' button. Visa's
 SDK handles the event and pops a lightbox where the user can authenticate and select a payment card.
-Visa checkout then calls a callback function on the merchant's webpage.
+Visa SRC then calls a callback function on the merchant's webpage.
 
 The one step process involves simply listening for a callback from Visa's SDK and calling our Payment API to complete the payment.
 
@@ -41,19 +41,19 @@ our API to retrieve addresses, and then calling our Payment API to complete the 
 
 ### Caveats
 
-Bambora's Visa Checkout integration is not compatible with 3D Secure.
+Bambora's Visa SRC integration is not compatible with 3D Secure.
 
 ### Testing
 
-Visa Checkout is not enabled by default on test accounts. Contact us at (support.northamerica@bambora.com)[mailto:support.northamerica@bambora.com]
+Visa SRC is not enabled by default on test accounts. Contact us at [support.northamerica@bambora.com](mailto:support.northamerica@bambora.com)
 and we will enable it.
 
-You can test visa checkout on sandbox-web.na.bambora.com.
+You can test Visa SRC on sandbox-web.na.bambora.com.
 
-### Visa Checkout SDK
+### Visa SRC SDK
 
-You will need to add Visa Checkout to your page and register a listener to handle
-payments originating from it. You can find out more (here)[https://developer.visa.com/capabilities/visa_checkout/docs].
+You will need to add Visa SRC to your page and register a listener to handle
+payments originating from it. You can find out more [here](https://developer.visa.com/capabilities/visa_checkout/docs).
 
 
 ### Example requests:
@@ -106,17 +106,17 @@ cardType=VI&cardLastFour=1234&trnAmount=10.00&authorizingMerchantId=123456789
 
 ## Advanced integration
 
-If you have integrated and certified to Visa’s Visa Checkout API and are handling the redirect to the Visa Checkout Portal
-independently of Bambora’s internal integration, you will need to pass the Visa Checkout Call ID with your Payment REST API
-request to Bambora. This ensures that your transaction is picked up by the Card Issuer as being a Visa Checkout transaction.
+If you have integrated and certified to Visa’s Visa SRC API and are handling the redirect to the Visa SRC Portal
+independently of Bambora’s internal integration, you will need to pass the Visa SRC Call ID with your Payment REST API
+request to Bambora. This ensures that your transaction is picked up by the Card Issuer as being a Visa SRC transaction.
 
 Note: This option must be enabled by us. Contact support if you want to use this method.
 
-The Visa Checkout Call ID must be sent with the transaction request using the following system variable:
+The Visa SRC Call ID must be sent with the transaction request using the following system variable:
 
 | Attribute | Description |
 | --- | --- |
-| visa_checkout_call_id | The payment request ID returned back from Visa Checkout. |
+| visa_checkout_call_id | The payment request ID returned back from Visa SRC. |
 
 
 #### Request

--- a/source/includes/na/analyze_payments/_code_samples.md
+++ b/source/includes/na/analyze_payments/_code_samples.md
@@ -35,7 +35,7 @@ try {
 Transaction trans = beanstream.Reporting.GetTransaction (TransactionId);
 ```
 
-You can retrieve a previous transaction using this method. All you need the the transaction ID.
+You can retrieve a previous transaction using this method. All you need is the transaction ID.
 
 You must use the correct API key for this method.
 

--- a/source/includes/na/take_payments/_payment_token.md
+++ b/source/includes/na/take_payments/_payment_token.md
@@ -89,7 +89,7 @@ PaymentResponse response = bambora.Payments.MakePayment (
 
 Single-use tokens provide a secure method of taking payments that reduces your PCI scope. You can take a payment using a token the same as you would take a payment with a credit card, the main difference being the ‘payment_method’ parameter and supplying the token.
 
-To process a transaction using a token, you first need to have created a token. You can either do this from the browser/client using the [Tokenization API](/docs/references/payment_APIs) or using the [Mobile or Browser SDKs](/docs/references/payment_SDKs/collect_card_data).
+To process a transaction using a token, you first need to have created a token. You can either do this from the browser/client using the [Tokenization API](/docs/references/payment_APIs) or using the [Browser SDKs](/docs/references/payment_SDKs/collect_card_data).
 
 A single-use token is a 'single-use nonce'. It is distinct from a multi-use Payment Profile token. See [here](/docs/references/payment_SDKs/save_customer_data).
 


### PR DESCRIPTION
Visa Checkout rebrand to SRC and [various fixes](https://confluence.beanstream.com/display/NAMP/Deprecate+Legacy+SDKs) identified by CX